### PR TITLE
Made sender name customizable

### DIFF
--- a/config/log-envelope.php
+++ b/config/log-envelope.php
@@ -13,6 +13,15 @@ return [
      * (default value: log-envelop@your-domain.com)
      */
     'email_from' => null,
+
+    /*
+     * The name of the sender.
+     * 
+     * (default value: Log Envelope)
+     */
+
+    'email_from_name' => '',
+
     
     /*
      * How many lines to show near exception line.

--- a/src/LogEnvelope.php
+++ b/src/LogEnvelope.php
@@ -19,6 +19,7 @@ class LogEnvelope
         $this->config['except'] = config('yaro.log-envelope.except', []);
         $this->config['email_to'] = config('yaro.log-envelope.email_to');
         $this->config['email_from'] = config('yaro.log-envelope.email_from');
+        $this->config['email_from_name'] = config('yaro.log-envelope.email_from_name', 'Log Envelope');
         $this->config['count'] = config('yaro.log-envelope.lines_count', 12);
         
         if (!$this->config['email_from']) {
@@ -54,7 +55,7 @@ class LogEnvelope
                 );
                 
                 $message->to($config['email_to'])
-                        ->from($config['email_from'], 'Log Envelope')
+                        ->from($config['email_from'], $config['email_from_name'])
                         ->subject($subject);
             });
         } catch (Exception $e) {


### PR DESCRIPTION
Currently the Sender's name is hardcoded to 'Log Envelope'; however, maybe making it customizable via config could be more beneficial. 
