### PR TITLE
Adding Mailable class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel", "log", "error", "mail on error"],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.3"
+        "illuminate/support": ">=5.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel", "log", "error", "mail on error"],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.*"
+        "illuminate/support": "5.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Drivers/Mail.php
+++ b/src/Drivers/Mail.php
@@ -3,6 +3,7 @@
 namespace Yaro\LogEnvelope\Drivers;
 
 use Illuminate\Support\Facades\Mail as MailFacade;
+use Yaro\LogEnvelope\Mail\LogEmail;
 
 class Mail extends AbstractDriver
 {
@@ -27,22 +28,7 @@ class Mail extends AbstractDriver
         $data = $this->data;
         $config = $this->config;
         
-        MailFacade::queue('log-envelope::main', $data, function($message) use ($data, $config) {
-            $subject = sprintf('[%s] @ %s: %s', $data['class'], $data['host'], $data['exception']);
-
-            // to protect from gmail's anchors automatic generating
-            $message->setBody(
-                preg_replace(
-                    ['~\.~', '~http~'],
-                    ['<span>.</span>', '<span>http</span>'],
-                    $message->getBody()
-                )
-            );
-
-            $message->to($config['to'])
-                ->from($config['from_email'], $config['from_name'])
-                ->subject($subject);
-        });
+        MailFacade::queue(new LogEmail($data, $config));
     } // end send
     
 }

--- a/src/Mail/LogEmail.php
+++ b/src/Mail/LogEmail.php
@@ -1,0 +1,48 @@
+<?php
+namespace Yaro\LogEnvelope\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class LogEmail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+    
+    public $data;
+    public $config;
+    
+    public function __construct($data, $config)
+    {
+        $this->data = $data;
+        $this->config = $config;
+    }
+    
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $subject = sprintf('[%s] @ %s: %s', $this->data['class'], $this->data['host'], $this->data['exception']);
+    
+        // to protect from gmail's anchors automatic generating
+        $this->withSwiftMessage(function ($message) {
+            $message->setBody(
+                preg_replace(
+                    ['~\.~', '~http~'],
+                    ['<span>.</span>', '<span>http</span>'],
+                    $message->getBody()
+                )
+            );
+        });
+        
+        return $this->view('log-envelope::main')
+            ->with($this->data)
+            ->to($this->config['to'])
+            ->from($this->config['from_email'], $this->config['from_name'])
+            ->subject($subject);
+    }
+}


### PR DESCRIPTION
Mail::queue() was not working for Laravel 5.4 because it requires Mailable objects to be used for queueing. I'm not using queueing, but since the library is using Mail::queue(), I couldn't send emails out.

I changed the composer.json so that it's aligned with the introduction of Mailables in 5.3