### PR TITLE
Add ability to define fields to censor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ public function report(Exception $e)
 
 Change config ```yaro.log-envelope.php``` for your needs. You can choose to log your errors to your database or send them to your email/telegram/slack. Emails are preferable, cuz they contains more debug information, such as traceback.
 
+There is a ```censored_fields``` option which will change any fields value to `*****` if it is named in this array. For example by default it will change values for fields called `password` to `*****`.
+
 Also there is ```force_config``` option, where you can define which configs to override for LogEnvelope execution. E.g., if you using some smtp for mail sending and queue it, you can change configs to send LogEnvelope emails immediately and not via smtp:
 ```
 'force_config' => [

--- a/config/log-envelope.php
+++ b/config/log-envelope.php
@@ -58,4 +58,11 @@ return [
         'Symfony\Component\Process\Exception\ProcessTimedOutException',
     ],
 
+    /*
+     * List of fields to censor
+     */
+    'censored_fields' => [
+        'password',
+    ],
+
 ];


### PR DESCRIPTION
This PR adds the ability to define a list of fields that values should be censored and not sent in any channel.

For example if an error occurs on a form submission for login then the password field is sent plain text. By default all fields called password are set to censored but you can define any other fields in the config file with the new config value of `censored_fields`. For example if you are storing credit card details and don't want those sent via email you could also add those field names to this array.

The censorSensitiveFields method runs over all storage arrays as it makes sense to do this to all input fields and areas where people can store details that are sensitive.