### PR TITLE
Fix Apple Mail Auto Linking

### DIFF
--- a/resources/views/main.blade.php
+++ b/resources/views/main.blade.php
@@ -3,6 +3,15 @@
     <head>
         <meta charset="utf-8">
         <title>Log Envelope</title>
+        <style>
+            /* 
+                Fix Apple Mail auto linking and coloring them as 
+                blue which is unreadable on the blue background. 
+            */
+            a {
+                color: white;
+            }
+        </style>
     </head>
     <body style="margin: 0px; padding: 0px;">
         <div style="padding: 10px; background-color: #55688A; color: white;">


### PR DESCRIPTION
Apple Mail auto links anything it considers to be a link within the body of an email. It then sets the colour of these to a blue which makes links unreadable. Below are before and after images.

<img width="277" alt="header-blue" src="https://user-images.githubusercontent.com/9828591/40801017-cd907d26-6509-11e8-9357-4de2167ce0aa.png">
<img width="281" alt="header-white" src="https://user-images.githubusercontent.com/9828591/40801015-cd5aad2c-6509-11e8-82a0-2ae09c337771.png">
<img width="746" alt="body-blue" src="https://user-images.githubusercontent.com/9828591/40801016-cd782c12-6509-11e8-9c4d-27975bb25ed2.png">
<img width="746" alt="body-white" src="https://user-images.githubusercontent.com/9828591/40801014-cd42a402-6509-11e8-8e9d-045c69da768b.png">

