### PR TITLE
Comment out default Force Config values

### DIFF
--- a/config/log-envelope.php
+++ b/config/log-envelope.php
@@ -40,8 +40,8 @@ return [
      * Change config for LogEnvelope execution.
      */
     'force_config' => [
-        'mail.driver' => 'sendmail',
-        'queue.default' => 'sync',
+        // 'mail.driver' => 'sendmail',
+        // 'queue.default' => 'sync',
     ],
 
     /*


### PR DESCRIPTION
If I install LogEnvelope and do not publish the config file the `force_config` array is empty.

If I then publish the LogEnvelope config file it will override my `mail.driver` and `queue.default`

This PR fixes that inconsistency by commenting out the values in the published config file so they are just examples and not applied.