### PR TITLE
Fix migrate:rollback down method

### DIFF
--- a/resources/migrations/create_exceptions_table.php.stub
+++ b/resources/migrations/create_exceptions_table.php.stub
@@ -40,7 +40,7 @@ class CreateExceptionsTable extends Migration
     public function down()
     {
         if (Schema::hasTable('exceptions')) {
-            gSchema::drop('exceptions');
+            Schema::drop('exceptions');
         }
     }
     


### PR DESCRIPTION
There was a typo in the `down()` method that would fail on a migrate:rollback