### PR TITLE
Make sure we haven't seek()'d past the last line

### DIFF
--- a/src/LogEnvelope.php
+++ b/src/LogEnvelope.php
@@ -152,6 +152,10 @@ class LogEnvelope
             return [false, false];
         }
         $file->seek($index);
+        
+        if($file->eof()) {
+            return [false, false];
+        }
 
         return [
             $file->__toString(),


### PR DESCRIPTION
Since upgrading to PHP 7.4 we kept seeing the following errors...

```
[2020-10-19 11:15:50] production.ERROR: RuntimeException: Cannot read from file /home/xxx/public_html/app/Class/Click.php in /home/xxx/public_html/vendor/yaro/log-envelope/src/LogEnvelope.php:159
```

After further investigation, we can see that LogEnvelope is trying to get a line from the file that is beyond the end of the file.

This check makes sure we are not trying to get a line that does not exist.