### PR TITLE
Use current() instead of __toString()

### DIFF
--- a/src/LogEnvelope.php
+++ b/src/LogEnvelope.php
@@ -158,9 +158,9 @@ class LogEnvelope
         }
 
         return [
-            $file->__toString(),
+            $file->current(),
             [
-                'line' => '<span style="color:#aaaaaa;">' . $currentLine . '.</span> ' . SyntaxHighlight::process($file->__toString()),
+                'line' => '<span style="color:#aaaaaa;">' . $currentLine . '.</span> ' . SyntaxHighlight::process($file->current()),
                 'wrap_left' => $i ? '' : '<span style="color: #F5F5F5; background-color: #5A3E3E; width: 100%; display: block;">',
                 'wrap_right' => $i ? '' : '</span>',
             ]


### PR DESCRIPTION
`__toString()` is just an alias. It used to be an alias of `current()` in PHP versions prior to 7.2.19 and 7.3.6. [See here](https://www.php.net/manual/en/splfileobject.tostring.php)

This has since been changed to be an alias of `fgets()` which moves to the next line of the file on each call.

This was causing this package to highlight the incorrect line, and also, on very short PHP files, prevents any error email actually being sent.

Thanks
