### PR TITLE
Fix single-quotes in syntax highlighting

### DIFF
--- a/src/SyntaxHighlight.php
+++ b/src/SyntaxHighlight.php
@@ -17,7 +17,7 @@ class SyntaxHighlight
 
     public function highlight($s)
     {
-        $s = htmlspecialchars($s, ENT_SUBSTITUTE | ENT_HTML401);
+        $s = htmlspecialchars($s, ENT_COMPAT);
 
         // Workaround for escaped backslashes
         $s = str_replace('\\\\', '\\\\<e>', $s);

--- a/src/SyntaxHighlight.php
+++ b/src/SyntaxHighlight.php
@@ -17,7 +17,7 @@ class SyntaxHighlight
 
     public function highlight($s)
     {
-        $s = htmlspecialchars($s);
+        $s = htmlspecialchars($s, ENT_SUBSTITUTE | ENT_HTML401);
 
         // Workaround for escaped backslashes
         $s = str_replace('\\\\', '\\\\<e>', $s);


### PR DESCRIPTION
Single quotes in the syntax highlighting are not handled properly. This changes should fix that.

# Before
<img width="300" alt="Screenshot 2022-04-01 at 12 23 27" src="https://user-images.githubusercontent.com/340752/161254235-17f27df4-4a71-4fad-a18b-b7b96aedca22.png">

# After
<img width="224" alt="Screenshot 2022-04-01 at 12 23 38" src="https://user-images.githubusercontent.com/340752/161254263-0537d17a-b71b-4300-8568-58448aac3010.png">


